### PR TITLE
Allow custom OpenAI-compatible endpoints

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,5 @@
 OPENAI_API_KEY=sk-proj-1234567890abcdef1234567890abcdef
+# Optional: use a custom OpenAI-compatible endpoint
+# OPENAI_BASE_URL=https://api.example.com/v1
+# Optional: override the model used for image generation
+# OPENAI_MODEL=dall-e-3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ $ ./image_to_ascii.py <input_image> <output_file>
 $ ./prompt_to_ascii.py <output_file> <prompt>
 ```
 
-To use `prompt_to_ascii.py` you need to add your OpenAI API key into a `.env` file (see `.env.sample`)
+To use `prompt_to_ascii.py` you need to add your OpenAI API key into a `.env` file (see `.env.sample`).
+You may also specify `OPENAI_BASE_URL` if using a custom OpenAI-compatible API endpoint and `OPENAI_MODEL` to set the image model.
 
 ## Example 1
 

--- a/prompt_to_ascii.py
+++ b/prompt_to_ascii.py
@@ -12,11 +12,14 @@ load_dotenv()
 
 client = OpenAI(
     api_key=os.getenv("OPENAI_API_KEY"),
+    base_url=os.getenv("OPENAI_BASE_URL"),
 )
 
+
 def create_image(prompt, output_image):
+    model = os.getenv("OPENAI_MODEL", "dall-e-3")
     response = client.images.generate(
-        model="dall-e-3",
+        model=model,
         prompt=prompt,
         size="1024x1024",
         response_format="b64_json",
@@ -26,6 +29,7 @@ def create_image(prompt, output_image):
 
     with open(output_image, "wb") as f:
         f.write(image)
+
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:


### PR DESCRIPTION
## Summary
- allow configuring OpenAI API base URL and model via environment variables
- document custom endpoint usage in README and sample env file

## Testing
- `python -m py_compile prompt_to_ascii.py image_to_ascii.py`
- `python -m pytest`
- `flake8 prompt_to_ascii.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa7be888832997bdb73f66611b80