### PR TITLE
Add Flask web UI for ASCII art

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ $ source venv/bin/activate
 $ pip install -r requirements.txt
 $ ./image_to_ascii.py <input_image> <output_file>
 $ ./prompt_to_ascii.py <output_file> <prompt>
+$ python webapp.py  # start web UI
 ```
+
+The web interface lets you adjust output width, choose from multiple character sets (Standard, Blocks, Dots, Dense, Binary), or supply a custom character string and download your ASCII art as text or image.
 
 To use `prompt_to_ascii.py` you need to add your OpenAI API key into a `.env` file (see `.env.sample`).
 You may also specify `OPENAI_BASE_URL` if using a custom OpenAI-compatible API endpoint and `OPENAI_MODEL` to set the image model.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pillow
 openai
 python-dotenv
+flask

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,36 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2em;
+  background: #f4f4f4;
+  color: #333;
+}
+
+h1 {
+  color: #444;
+}
+
+form {
+  margin-bottom: 2em;
+  padding: 1em;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+input[type="text"],
+input[type="number"],
+select {
+  margin: 0.5em 0;
+}
+
+pre.ascii-art {
+  font: 10px/10px monospace;
+  color: white;
+  background: black;
+  padding: 1em;
+  display: inline-block;
+}
+
+.links {
+  margin-top: 1em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+<head>
+  <title>Asskey Web</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <h1>Upload Image for ASCII Art</h1>
+  <form action="/upload" method="post" enctype="multipart/form-data">
+    <label>Image:
+      <input type="file" name="image" accept="image/*" required>
+    </label><br>
+    <label>Width:
+      <input type="number" name="width" value="160" min="20" max="400">
+    </label><br>
+    <label>Character Set:
+      <select name="charset">
+        <option value="standard">Standard</option>
+        <option value="blocks">Blocks</option>
+        <option value="dots">Dots</option>
+        <option value="dense">Dense</option>
+        <option value="binary">Binary</option>
+      </select>
+    </label><br>
+    <label>Custom Charset:
+      <input type="text" name="custom_charset" placeholder="Override preset">
+    </label><br>
+    <input type="submit" value="Convert">
+  </form>
+
+  <h1>Generate ASCII Art from Prompt</h1>
+  <form action="/prompt" method="post">
+    <label>Prompt:
+      <input type="text" name="prompt" placeholder="Enter prompt" required>
+    </label><br>
+    <label>Width:
+      <input type="number" name="width" value="160" min="20" max="400">
+    </label><br>
+    <label>Character Set:
+      <select name="charset">
+        <option value="standard">Standard</option>
+        <option value="blocks">Blocks</option>
+        <option value="dots">Dots</option>
+        <option value="dense">Dense</option>
+        <option value="binary">Binary</option>
+      </select>
+    </label><br>
+    <label>Custom Charset:
+      <input type="text" name="custom_charset" placeholder="Override preset">
+    </label><br>
+    <input type="submit" value="Generate">
+  </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+  <title>ASCII Art Result</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <h1>ASCII Art Result</h1>
+  <pre class="ascii-art">{{ ascii_art }}</pre>
+  <div class="links">
+    <a href="/download/txt?data={{ data }}">Download as Text</a> |
+    <a href="/download/img?data={{ data }}">Download as Image</a>
+  </div>
+  <br>
+  <a href="/">Back</a>
+</body>
+</html>

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from flask import Flask, render_template, request, Response, send_file
+import tempfile
+import os
+import base64
+import urllib.parse
+import io
+from image_to_ascii import create_ascii_art, save_ascii_image
+from prompt_to_ascii import create_image
+
+app = Flask(__name__)
+
+CHARSETS = {
+    'standard': ' .-~:+=*#%@',
+    'blocks': ' ░▒▓█',
+    'dots': ' .oO@',
+    'dense': '@%#*+=-:. ',
+    'binary': '01',
+}
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    uploaded = request.files.get('image')
+    if not uploaded or uploaded.filename == '':
+        return 'No image uploaded', 400
+    width = int(request.form.get('width', 160))
+    custom_charset = request.form.get('custom_charset', '').strip()
+    charset_key = request.form.get('charset', 'standard')
+    charset = custom_charset or CHARSETS.get(charset_key, CHARSETS['standard'])
+    suffix = os.path.splitext(uploaded.filename)[1]
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        uploaded.save(tmp.name)
+        ascii_art = create_ascii_art(tmp.name, ascii_chars=charset, width=width)
+    data = urllib.parse.quote_plus(base64.b64encode(ascii_art.encode()).decode())
+    return render_template('result.html', ascii_art=ascii_art, data=data)
+
+@app.route('/prompt', methods=['POST'])
+def prompt_to_ascii():
+    prompt = request.form.get('prompt')
+    if not prompt:
+        return 'No prompt provided', 400
+    width = int(request.form.get('width', 160))
+    custom_charset = request.form.get('custom_charset', '').strip()
+    charset_key = request.form.get('charset', 'standard')
+    charset = custom_charset or CHARSETS.get(charset_key, CHARSETS['standard'])
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.webp') as tmp:
+        create_image(prompt, tmp.name)
+        ascii_art = create_ascii_art(tmp.name, ascii_chars=charset, width=width)
+    data = urllib.parse.quote_plus(base64.b64encode(ascii_art.encode()).decode())
+    return render_template('result.html', ascii_art=ascii_art, data=data)
+
+@app.route('/download/txt')
+def download_txt():
+    data = request.args.get('data')
+    if not data:
+        return 'No data provided', 400
+    ascii_art = base64.b64decode(data.encode()).decode()
+    return Response(
+        ascii_art,
+        mimetype='text/plain',
+        headers={'Content-Disposition': 'attachment; filename=ascii_art.txt'}
+    )
+
+@app.route('/download/img')
+def download_img():
+    data = request.args.get('data')
+    if not data:
+        return 'No data provided', 400
+    ascii_art = base64.b64decode(data.encode()).decode()
+    buf = io.BytesIO()
+    save_ascii_image(ascii_art, buf)
+    buf.seek(0)
+    return send_file(buf, mimetype='image/png', as_attachment=True, download_name='ascii_art.png')
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add configurable output width and character sets for ASCII art generation
- style web pages and offer download links for ASCII art as text or image
- document web interface features in README
- allow selecting new character sets or providing a custom string for ASCII rendering

## Testing
- `python -m py_compile webapp.py image_to_ascii.py prompt_to_ascii.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6fbff8e988329ab5d2183d9fcc880